### PR TITLE
NCIATWP-10154 - Fix API Access page crash on large search responses

### DIFF
--- a/client/src/components/swagger-ui/swagger-large-response-fix.js
+++ b/client/src/components/swagger-ui/swagger-large-response-fix.js
@@ -1,0 +1,37 @@
+import React from "react";
+
+// Swagger UI syntax-highlights every response body with react-syntax-highlighter (highlight.js).
+// On very large / deeply-nested responses — e.g. broad `/api/search` keyword queries like "neck"
+// that return many MB — the highlighter recurses past the call-stack limit and the whole response
+// panel crashes with "RangeError: Maximum call stack size exceeded" ("Could not render $e").
+// See NCIATWP-10154.
+//
+// swagger-ui-react@4.19 does not forward the `syntaxHighlight` config option, so we disable
+// highlighting only where it would crash: this plugin wraps the `highlightCode` component and
+// renders oversized bodies as plain <pre> text. Normal-sized responses are untouched and keep
+// their syntax highlighting and copy/download controls.
+
+// Response bodies longer than this (in characters) skip highlighting to avoid the stack overflow.
+// Comfortably above typical single-code lookups; well below the multi-MB keyword responses.
+const MAX_HIGHLIGHT_LENGTH = 100000;
+
+const SwaggerLargeResponseHighlightFix = () => ({
+  wrapComponents: {
+    highlightCode: (Original) => (props) => {
+      const value = props && typeof props.value === "string" ? props.value : "";
+
+      if (value.length > MAX_HIGHLIGHT_LENGTH) {
+        const className = `${props.className || ""} microlight`.trim();
+        return (
+          <div className="highlight-code">
+            <pre className={className}>{value}</pre>
+          </div>
+        );
+      }
+
+      return <Original {...props} />;
+    },
+  },
+});
+
+export default SwaggerLargeResponseHighlightFix;

--- a/client/src/modules/api-access/api-access.js
+++ b/client/src/modules/api-access/api-access.js
@@ -3,6 +3,7 @@ import SwaggerUI from "swagger-ui-react";
 import SwaggerLabelInjector from "../../components/swagger-ui/swagger-injecttion";
 import SwaggerColorCustomizer from "../../components/swagger-ui/swagger-color-customizer";
 import SwaggerScrollablePreEnhancer from "../../components/swagger-ui/swagger-scrollable";
+import SwaggerLargeResponseHighlightFix from "../../components/swagger-ui/swagger-large-response-fix";
 
 export default function ApiAccess() {
   return (
@@ -18,7 +19,7 @@ export default function ApiAccess() {
           The ICD Genie API provides programmatic access to endpoints which allow users to search and translate ICD-10,
           ICD-10-PCS, ICD-11, ICD-O-3, and ICD-O-4 codes. The following resources are available:
         </p>
-        <SwaggerUI url={process.env.PUBLIC_URL + "/api"} />
+        <SwaggerUI url={process.env.PUBLIC_URL + "/api"} plugins={[SwaggerLargeResponseHighlightFix]} />
         {/* Add SwaggerLabelInjector to observe and inject the label */}
         <SwaggerLabelInjector />
         {/* Custom integer color styling */}


### PR DESCRIPTION
[NCIATWP-10154](https://tracker.nci.nih.gov/browse/NCIATWP-10154)

Fixes a crash on the API Access page where running a Search that returns a large result (e.g. broad keywords like "neck") would fail to display with a "Could not render" error. Large responses now display reliably.
  
- Render very large API responses as plain text on the API Access page instead of running them through the syntax highlighter, which was overflowing on big payloads.
- Keep syntax highlighting and copy controls for normal-sized responses.