### PR TITLE
NCIATWP-10388/10389/10822/10846

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -15,7 +15,6 @@ import FAQ from "./modules/about/faq";
 import Started from "./modules/about/getting-started";
 import BatchQuery from "./modules/batch-query/batch-query";
 import Translate from "./modules/translate/translate";
-import BatchTranslate from "./modules/batch-translate/batch-translate";
 import "./styles/main.scss";
 
 export default function App() {
@@ -44,11 +43,6 @@ export default function App() {
       route: "/translate",
       title: "Translate",
       component: Translate,
-    },
-    {
-      route: "/batch-translate",
-      title: "Batch Translate",
-      component: BatchTranslate,
     },
     {
       route: "/api-access",

--- a/client/src/modules/search/search.icd10.js
+++ b/client/src/modules/search/search.icd10.js
@@ -1,9 +1,12 @@
 import { useEffect, useState } from "react";
+import { DataTypeProvider } from "@devexpress/dx-react-grid";
 import { TreeDataState, CustomTreeData } from "@devexpress/dx-react-grid";
 import { Grid, Table, TableHeaderRow, TableTreeColumn } from "@devexpress/dx-react-grid-bootstrap4";
 import Container from "react-bootstrap/Container";
+import { useNavigate } from "react-router-dom";
 
 export default function ICD10({ maps, search }) {
+  const navigate = useNavigate();
   const [tabularOpen, setTabularOpen] = useState([])
 
   useEffect(() => {
@@ -42,8 +45,21 @@ export default function ICD10({ maps, search }) {
     return rootRows;
   }
 
-  function IcdCodeTypeProvider({ value }) {
-    return value
+  function IcdCodeTypeProvider(props) {
+    function CodeLink({ value: code }) {
+      if (!code) return code;
+      return (
+        <button
+          type="button"
+          className="btn btn-link p-0 align-baseline"
+          onClick={() => navigate("/translate", { state: { code, from: "icd10" } })}
+        >
+          {code}
+        </button>
+      );
+    }
+
+    return <DataTypeProvider formatterComponent={CodeLink} {...props} />;
   }
 
   return (

--- a/client/src/modules/search/search.icd11.js
+++ b/client/src/modules/search/search.icd11.js
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
+import { DataTypeProvider } from "@devexpress/dx-react-grid";
 import Accordion from "react-bootstrap/Accordion";
 import { TreeDataState, CustomTreeData } from "@devexpress/dx-react-grid";
 import { Grid, Table, TableHeaderRow, TableTreeColumn } from "@devexpress/dx-react-grid-bootstrap4";
 import Container from "react-bootstrap/Container";
+import { useNavigate } from "react-router-dom";
 
 export default function ICD11({ maps, search }) {
+  const navigate = useNavigate();
   const [panel, setPanel] = useState(null);
   const [expandedRows, setExpandedRows] = useState([]);
 
@@ -41,8 +44,21 @@ export default function ICD11({ maps, search }) {
     return rootRows;
   }
 
-  function IcdCodeTypeProvider({ value }) {
-    return value;
+  function IcdCodeTypeProvider(props) {
+    function CodeLink({ value: code }) {
+      if (!code) return code;
+      return (
+        <button
+          type="button"
+          className="btn btn-link p-0 align-baseline"
+          onClick={() => navigate("/translate", { state: { code, from: "icd11" } })}
+        >
+          {code}
+        </button>
+      );
+    }
+
+    return <DataTypeProvider formatterComponent={CodeLink} {...props} />;
   }
 
   function handleAccordion() {

--- a/client/src/modules/translate/translate.js
+++ b/client/src/modules/translate/translate.js
@@ -1,14 +1,16 @@
 import { useRecoilState } from "recoil";
 import axios from "axios";
 import { Form, Container, Row, Col, Button } from "react-bootstrap";
-import { Link } from "react-router-dom";
+import { useLocation, useNavigate, Link } from "react-router-dom";
 import Loader from "../common/loader";
 import { formState, resultsState } from "./translate.state";
 import DirectionToggle from "./direction-toggle";
 import { TranslateResult, TranslationDisclaimer } from "./translation-result";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function Translate() {
+  const location = useLocation();
+  const navigate = useNavigate();
   const [form, setForm] = useRecoilState(formState);
   const [results, setResults] = useRecoilState(resultsState);
   const mergeForm = (obj) => setForm({ ...form, ...obj });
@@ -25,6 +27,29 @@ export default function Translate() {
 
   const directionLabel =
     form.from === "icd10" ? "ICD-10-CM → ICD-11" : "ICD-11 → ICD-10-CM";
+
+  useEffect(() => {
+    const state = location.state;
+    if (!state?.code || !state?.from) return;
+
+    const nextForm = { code: state.code, from: state.from };
+    setForm((prev) => ({ ...prev, ...nextForm }));
+    setResults({ loading: true, data: null });
+    setSubmitError("");
+
+    (async () => {
+      try {
+        const response = await axios.post("api/translate", nextForm);
+        setResults({ loading: false, data: response.data });
+      } catch (error) {
+        console.error("Translate error:", error);
+        setResults({ loading: false, data: null });
+        setSubmitError("An error occurred. Please try again.");
+      } finally {
+        navigate(location.pathname, { replace: true, state: null });
+      }
+    })();
+  }, [location.state, location.pathname, navigate, setForm, setResults]);
 
   async function handleSubmit(event) {
     event.preventDefault();
@@ -65,14 +90,15 @@ export default function Translate() {
           <Row className="justify-content-center">
             <Col md={8}>
               <Form.Group className="mb-3">
-                <Form.Label>Translate a single code between ICD-10-CM and ICD-11.</Form.Label>
+                <Form.Label>
+                  Use this feature to translate a single code from ICD-10-CM to ICD-11 or from ICD-11 to ICD-10-CM.
+                </Form.Label>
                 <p>
-                  ICD-11 → ICD-10-CM is a one-to-one match. ICD-10-CM → ICD-11 can map to a
-                  combination of codes, shown below with <b>AND</b> / <b>OR</b> logic. To translate a
-                  whole list at once, use <Link to="/batch-translate">Batch Translate</Link>. For code
-                  formatting help, see the <Link to="/getting-started">Getting Started</Link> page.
+                    ICD-11 → ICD-10-CM is a one-to-one match. ICD-10-CM → ICD-11 can map to a
+                    combination of codes, shown below with <b>AND</b> / <b>OR</b> logic. For code
+                    formatting help, see the <Link to="/getting-started">Getting Started</Link> page.
                 </p>
-              </Form.Group>
+                </Form.Group>
             </Col>
           </Row>
 

--- a/client/src/modules/translate/translation-result.js
+++ b/client/src/modules/translate/translation-result.js
@@ -1,11 +1,25 @@
 import { Row, Col } from "react-bootstrap";
 
 // One translation entry, laid out left-to-right: source on the left, the ICD-11/ICD-10 mapping on the
-// right. Per the client (questions.md A1), the mapping is shown EXACTLY as it appears in the WHO
-// mapping file — the `&`/`/` combination string is not parsed. <TranslationDisclaimer/> explains the
-// symbols. Reused for the single Translate result and each row of Batch Translate.
+// right. The WHO mapping file encodes alternate rows as ` / ` separators while keeping compound
+// codes like `1B11.Y/1D02.0` intact. We render each alternate row separately so the UI matches the
+// ticket mockup. <TranslationDisclaimer/> explains the symbols. Reused for the single Translate
+// result and each row of Batch Translate.
+function splitRows(value) {
+  return String(value ?? "")
+    .split(/\s+\/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
 export function TranslateResult({ data, idLabel }) {
   const { source, targetSystem, target, found, message } = data;
+  const codeRows = found && target?.code ? splitRows(target.code) : [];
+  const titleRows = found && target?.title ? splitRows(target.title) : [];
+  const mappedRows = codeRows.map((code, index) => ({
+    code,
+    title: titleRows[index] ?? "",
+  }));
   return (
     <Row className="border rounded bg-white mx-0 py-3">
       {idLabel != null && (
@@ -28,12 +42,25 @@ export function TranslateResult({ data, idLabel }) {
           Translation{targetSystem ? ` (${targetSystem})` : ""}
         </div>
         {found && target?.code ? (
-          <>
-            <div className="fw-bold font-monospace" style={{ fontSize: "1.05rem", wordBreak: "break-word" }}>
-              {target.code}
-            </div>
-            {target.title ? <div className="text-muted">{target.title}</div> : null}
-          </>
+          <div className="d-flex flex-column gap-2">
+            {mappedRows.length > 0 ? (
+              mappedRows.map(({ code, title }, index) => (
+                <div key={`${code}-${index}`}>
+                  <div className="fw-bold font-monospace" style={{ fontSize: "1.05rem", wordBreak: "break-word" }}>
+                    {code}
+                  </div>
+                  {title ? <div className="text-muted">{title}</div> : null}
+                </div>
+              ))
+            ) : (
+              <>
+                <div className="fw-bold font-monospace" style={{ fontSize: "1.05rem", wordBreak: "break-word" }}>
+                  {target.code}
+                </div>
+                {target.title ? <div className="text-muted">{target.title}</div> : null}
+              </>
+            )}
+          </div>
         ) : (
           <div className="alert alert-warning mb-0 py-2">{message || "No translation found."}</div>
         )}


### PR DESCRIPTION
## Summary
- **NCIATWP-10388 / NCIATWP-10389**: Clicking an ICD-10-CM or ICD-11 code in Search Results now navigates to the Translate page with the code pre-filled, the correct direction selected, and the translation auto-submitted.
- **NCIATWP-10822**: Updated Translate page intro text (removed Batch Translate reference); output table now displays multiple rows when the WHO mapping source has alternate rows for a code.
- **NCIATWP-10846**: Removed the Batch Translate route and nav link from `app.js` (module files kept in place, not deleted, in case it's needed later).

## Testing
Tested locally by the requester.